### PR TITLE
split mtime into sec and nanos

### DIFF
--- a/cmd/revad/svcs/grpcsvcs/storageprovidersvc/storageprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/storageprovidersvc/storageprovidersvc.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	storagetypespb "github.com/cernbox/go-cs3apis/cs3/storagetypes"
+	typespb "github.com/cernbox/go-cs3apis/cs3/types"
 
 	"github.com/cernbox/reva/cmd/revad/grpcserver"
 	"github.com/cernbox/reva/cmd/revad/svcs/grpcsvcs/utils"
@@ -835,13 +836,16 @@ func (s *service) toInfo(md *storage.MD) *storageproviderv0alphapb.ResourceInfo 
 		Sum:  md.Checksum,
 	}
 	info := &storageproviderv0alphapb.ResourceInfo{
-		Type:          getResourceType(md.IsDir),
-		Id:            id,
-		Path:          md.Path,
-		Checksum:      checksum,
-		Etag:          md.Etag,
-		MimeType:      md.Mime,
-		Mtime:         utils.UnixNanoToTS(md.Mtime),
+		Type:     getResourceType(md.IsDir),
+		Id:       id,
+		Path:     md.Path,
+		Checksum: checksum,
+		Etag:     md.Etag,
+		MimeType: md.Mime,
+		Mtime: &typespb.Timestamp{
+			Seconds: md.Mtime.Seconds,
+			Nanos:   md.Mtime.Nanos,
+		},
 		Size:          md.Size,
 		PermissionSet: perm,
 	}

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -741,7 +741,12 @@ func (c *Client) mapToFileInfo(kv map[string]string) (*FileInfo, error) {
 	}
 
 	// mtime is split by a dot, we only take the first part, do we need subsec precision?
-	mtime, err := strconv.ParseUint(strings.Split(kv["mtime"], ".")[0], 10, 64)
+	mtime := strings.Split(kv["mtime"], ".")
+	mtimesec, err := strconv.ParseUint(mtime[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	mtimenanos, err := strconv.ParseUint(mtime[1], 10, 32)
 	if err != nil {
 		return nil, err
 	}
@@ -752,34 +757,36 @@ func (c *Client) mapToFileInfo(kv map[string]string) (*FileInfo, error) {
 	}
 
 	fi := &FileInfo{
-		File:      kv["file"],
-		Inode:     inode,
-		FID:       fid,
-		ETag:      kv["etag"],
-		Size:      size,
-		TreeSize:  treeSize,
-		MTime:     mtime,
-		IsDir:     isDir,
-		Instance:  c.opt.URL,
-		SysACL:    kv["sys.acl"],
-		TreeCount: treeCount,
+		File:       kv["file"],
+		Inode:      inode,
+		FID:        fid,
+		ETag:       kv["etag"],
+		Size:       size,
+		TreeSize:   treeSize,
+		MTimeSec:   mtimesec,
+		MTimeNanos: uint32(mtimenanos),
+		IsDir:      isDir,
+		Instance:   c.opt.URL,
+		SysACL:     kv["sys.acl"],
+		TreeCount:  treeCount,
 	}
 	return fi, nil
 }
 
 // FileInfo represents the metadata information returned by querying the EOS namespace.
 type FileInfo struct {
-	File      string `json:"eos_file"`
-	Inode     uint64 `json:"inode"`
-	FID       uint64 `json:"fid"`
-	ETag      string
-	TreeSize  uint64
-	MTime     uint64
-	Size      uint64
-	IsDir     bool
-	Instance  string
-	SysACL    string
-	TreeCount uint64
+	File       string `json:"eos_file"`
+	Inode      uint64 `json:"inode"`
+	FID        uint64 `json:"fid"`
+	ETag       string
+	TreeSize   uint64
+	MTimeSec   uint64
+	MTimeNanos uint32
+	Size       uint64
+	IsDir      bool
+	Instance   string
+	SysACL     string
+	TreeCount  uint64
 }
 
 // DeletedEntry represents an entry from the trashbin.

--- a/pkg/storage/fs/local/local.go
+++ b/pkg/storage/fs/local/local.go
@@ -94,7 +94,9 @@ func (fs *localFS) normalize(fi os.FileInfo, fn string) *storage.MD {
 		Mime:        mime.Detect(fi.IsDir(), fn),
 		Size:        uint64(fi.Size()),
 		Permissions: &storage.PermissionSet{ListContainer: true, CreateContainer: true},
-		Mtime:       uint64(fi.ModTime().Unix()),
+		Mtime: &storage.Timestamp{
+			Seconds: uint64(fi.ModTime().Unix()),
+		},
 	}
 	//logger.Println(context.Background(), "normalized: ", md)
 	return md

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -77,13 +77,19 @@ type MD struct {
 	ID          string
 	Path        string
 	Size        uint64
-	Mtime       uint64
+	Mtime       *Timestamp
 	IsDir       bool
 	Etag        string
 	Checksum    string
 	Mime        string
 	Permissions *PermissionSet
 	Opaque      map[string]interface{}
+}
+
+// Timestamp allows passing around a timestamp with sub second precision
+type Timestamp struct {
+	Seconds uint64
+	Nanos   uint32
 }
 
 // PermissionSet is the set of permissions for a resource.


### PR DESCRIPTION
I was getting wrong mtimes. I assume because utils.UnixNanoToTS is not working as expected.

In any case I think it makes more sense to pass around Seconds and Nanos independently