### PR TITLE
Fix comma in content disposition filename

### DIFF
--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -123,8 +123,8 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	info := sRes.Info
 
 	w.Header().Set(HeaderContentType, info.MimeType)
-	w.Header().Set(HeaderContentDisposistion, "attachment; filename*=UTF-8''"+
-		path.Base(r.URL.Path)+"; filename=\""+path.Base(r.URL.Path)+"\"")
+	w.Header().Set(HeaderContentDisposistion, "attachment; filename*=UTF-8\""+
+		path.Base(r.URL.Path)+"\"; filename=\""+path.Base(r.URL.Path)+"\"")
 	w.Header().Set(HeaderETag, info.Etag)
 	w.Header().Set(HeaderOCFileID, resourceid.OwnCloudResourceIDWrap(info.Id))
 	w.Header().Set(HeaderOCETag, info.Etag)


### PR DESCRIPTION
Fix filename of a download when it contains a comma `,`.