### PR TITLE
Fix delete/modify share from project

### DIFF
--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -39,7 +39,6 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 
@@ -836,8 +835,7 @@ func (h *Handler) listSharesWithOthers(w http.ResponseWriter, r *http.Request) {
 		shares = append(shares, publicShares...)
 	}
 	if listUserShares {
-		r = r.WithContext(ctxpkg.ContextSetResourcePath(r.Context(), p))
-		userShares, status, err := h.listUserShares(r, filters)
+		userShares, status, err := h.listUserShares(r, filters, p)
 		h.logProblems(status, err, "could not listUserShares")
 		shares = append(shares, userShares...)
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -39,6 +39,7 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 
@@ -835,6 +836,7 @@ func (h *Handler) listSharesWithOthers(w http.ResponseWriter, r *http.Request) {
 		shares = append(shares, publicShares...)
 	}
 	if listUserShares {
+		r = r.WithContext(ctxpkg.ContextSetResourcePath(r.Context(), p))
 		userShares, status, err := h.listUserShares(r, filters)
 		h.logProblems(status, err, "could not listUserShares")
 		shares = append(shares, userShares...)

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -29,6 +29,7 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
@@ -169,12 +170,17 @@ func (h *Handler) removeUserShare(w http.ResponseWriter, r *http.Request, shareI
 	response.WriteOCSSuccess(w, r, data)
 }
 
-func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filter) ([]*conversions.ShareData, *rpc.Status, error) {
+func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filter, ctxPath string) ([]*conversions.ShareData, *rpc.Status, error) {
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 
 	lsUserSharesRequest := collaboration.ListSharesRequest{
 		Filters: filters,
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				ctxpkg.ResoucePathCtx: {Decoder: "plain", Value: []byte(ctxPath)},
+			},
+		},
 	}
 
 	ocsDataPayload := make([]*conversions.ShareData, 0)


### PR DESCRIPTION
An admin is able to list all the shares created by the other admins in the project spaces.
But was not able to delete / update a share.
This has been fixed in this PR.