### PR TITLE
Keep original ratio of generated thumbnails

### DIFF
--- a/internal/http/services/thumbnails/handler.go
+++ b/internal/http/services/thumbnails/handler.go
@@ -62,14 +62,14 @@ const (
 )
 
 type config struct {
-	GatewaySVC   string                            `mapstructure:"gateway_svc"`
-	Quality      int                               `mapstructure:"quality"`
-	Resolutions  []string                          `mapstructure:"quality"`
-	Cache        string                            `mapstructure:"cache"`
-	CacheDrivers map[string]map[string]interface{} `mapstructure:"cache_drivers"`
-	OutputType   string                            `mapstructure:"output_type"`
-	Prefix       string                            `mapstructure:"prefix"`
-	Insecure     bool                              `mapstructure:"insecure"`
+	GatewaySVC       string                            `mapstructure:"gateway_svc"`
+	Quality          int                               `mapstructure:"quality"`
+	FixedResolutions []string                          `mapstructure:"fixed_resolutions"`
+	Cache            string                            `mapstructure:"cache"`
+	CacheDrivers     map[string]map[string]interface{} `mapstructure:"cache_drivers"`
+	OutputType       string                            `mapstructure:"output_type"`
+	Prefix           string                            `mapstructure:"prefix"`
+	Insecure         bool                              `mapstructure:"insecure"`
 }
 
 type svc struct {
@@ -109,10 +109,10 @@ func New(conf map[string]interface{}, log *zerolog.Logger) (global.Service, erro
 	d := downloader.NewDownloader(gtw, rhttp.Insecure(c.Insecure))
 
 	mgr, err := manager.NewThumbnail(d, &manager.Config{
-		Quality:      c.Quality,
-		Resolutions:  c.Resolutions,
-		Cache:        c.Cache,
-		CacheDrivers: c.CacheDrivers,
+		Quality:          c.Quality,
+		FixedResolutions: c.FixedResolutions,
+		Cache:            c.Cache,
+		CacheDrivers:     c.CacheDrivers,
 	}, log)
 	if err != nil {
 		return nil, err

--- a/internal/http/services/thumbnails/manager/resolutions_test.go
+++ b/internal/http/services/thumbnails/manager/resolutions_test.go
@@ -1,0 +1,124 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package manager
+
+import (
+	"image"
+	"testing"
+)
+
+func TestResize(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested image.Rectangle
+		source    image.Rectangle
+		expected  image.Rectangle
+	}{
+		{
+			name:      "source and requested with same size",
+			requested: image.Rect(0, 0, 1920, 1080),
+			source:    image.Rect(0, 0, 1920, 1080),
+			expected:  image.Rect(0, 0, 1920, 1080),
+		},
+		{
+			name:      "same ratio",
+			requested: image.Rect(0, 0, 1280, 720),
+			source:    image.Rect(0, 0, 1920, 1080),
+			expected:  image.Rect(0, 0, 1280, 720),
+		},
+		{
+			name:      "source bigger ratio",
+			requested: image.Rect(0, 0, 1280, 720),
+			source:    image.Rect(0, 0, 1920, 920),
+			expected:  image.Rect(0, 0, 1280, 613),
+		},
+		{
+			name:      "source height < requested height - source ratio > requested ratio",
+			requested: image.Rect(0, 0, 1080, 1920),
+			source:    image.Rect(0, 0, 1920, 1080),
+			expected:  image.Rect(0, 0, 1080, 607),
+		},
+		{
+			name:      "source height > requested height - source ratio < requested ratio",
+			requested: image.Rect(0, 0, 1080, 600),
+			source:    image.Rect(0, 0, 1920, 1080),
+			expected:  image.Rect(0, 0, 1066, 600),
+		},
+		{
+			name:      "portrait source",
+			requested: image.Rect(0, 0, 1280, 1280),
+			source:    image.Rect(0, 0, 1080, 1920),
+			expected:  image.Rect(0, 0, 720, 1280),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			res := resize(tt.requested, tt.source)
+			if res.Dx() != tt.expected.Dx() || res.Dy() != tt.expected.Dy() {
+				t.Fatalf("resize() failed: requested=%+v source=%+v expected=%+v got=%+v", tt.requested, tt.source, tt.expected, res)
+			}
+
+		})
+
+	}
+}
+
+func TestMatchOrResize(t *testing.T) {
+	tests := []struct {
+		name             string
+		matchResolutions Resolutions
+		requested        image.Rectangle
+		source           image.Rectangle
+		expected         image.Rectangle
+	}{
+		{
+			name:             "matched",
+			matchResolutions: []image.Rectangle{image.Rect(0, 0, 64, 64)},
+			requested:        image.Rect(0, 0, 64, 64),
+			source:           image.Rect(0, 0, 1920, 1080),
+			expected:         image.Rect(0, 0, 64, 64),
+		},
+		{
+			name:      "requested bigger than source - landscape",
+			requested: image.Rect(0, 0, 5000, 5000),
+			source:    image.Rect(0, 0, 1920, 1080),
+			expected:  image.Rect(0, 0, 1920, 1080),
+		},
+		{
+			name:      "requested bigger than source - portrait",
+			requested: image.Rect(0, 0, 5000, 5000),
+			source:    image.Rect(0, 0, 1080, 1920),
+			expected:  image.Rect(0, 0, 1080, 1920),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			res := tt.matchResolutions.MatchOrResize(tt.requested, tt.source)
+			if res.Dx() != tt.expected.Dx() || res.Dy() != tt.expected.Dy() {
+				t.Fatalf("resize() failed: requested=%+v source=%+v expected=%+v got=%+v", tt.requested, tt.source, tt.expected, res)
+			}
+
+		})
+
+	}
+}


### PR DESCRIPTION
This PR improved the method on how the thumbnails are generated, keeping the original ratio in the generated image.
Also, allows in the config to specify some fixed sizes that are chosen even if the original ration is not respected, useful for small icon thumbnails.