### PR TITLE
Serverless services

### DIFF
--- a/cmd/revad/runtime/loader.go
+++ b/cmd/revad/runtime/loader.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/cs3org/reva/internal/http/interceptors/auth/tokenwriter/loader"
 	_ "github.com/cs3org/reva/internal/http/interceptors/loader"
 	_ "github.com/cs3org/reva/internal/http/services/loader"
+	_ "github.com/cs3org/reva/internal/serverless/services/loader"
 	_ "github.com/cs3org/reva/pkg/app/provider/loader"
 	_ "github.com/cs3org/reva/pkg/app/registry/loader"
 	_ "github.com/cs3org/reva/pkg/appauth/manager/loader"

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/registry/memory"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rhttp"
+	"github.com/cs3org/reva/pkg/rserverless"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
@@ -93,13 +94,20 @@ func run(mainConf map[string]interface{}, coreConf *coreConf, logger *zerolog.Lo
 	initCPUCount(coreConf, logger)
 
 	servers := initServers(mainConf, logger)
+	serverless := initServerless(mainConf, logger)
+
+	if len(servers) == 0 && serverless == nil {
+		logger.Info().Msg("nothing to do, no grpc/http/serverless enabled_services declared in config")
+		os.Exit(1)
+	}
+
 	watcher, err := initWatcher(logger, filename)
 	if err != nil {
 		log.Panic(err)
 	}
 	listeners := initListeners(watcher, servers, logger)
 
-	start(mainConf, servers, listeners, logger, watcher)
+	start(mainConf, servers, serverless, listeners, logger, watcher)
 }
 
 func initListeners(watcher *grace.Watcher, servers map[string]grace.Server, log *zerolog.Logger) map[string]net.Listener {
@@ -141,11 +149,19 @@ func initServers(mainConf map[string]interface{}, log *zerolog.Logger) map[strin
 		servers["grpc"] = s
 	}
 
-	if len(servers) == 0 {
-		log.Info().Msg("nothing to do, no grpc/http enabled_services declared in config")
-		os.Exit(1)
-	}
 	return servers
+}
+
+func initServerless(mainConf map[string]interface{}, log *zerolog.Logger) *rserverless.Serverless {
+	if isEnabledServerless(mainConf) {
+		serverless, err := getServerless(mainConf["serverless"], log)
+		if err != nil {
+			log.Error().Err(err).Msg("error")
+		}
+		return serverless
+	}
+
+	return nil
 }
 
 func initTracing(conf *coreConf) {
@@ -184,7 +200,7 @@ func handlePIDFlag(l *zerolog.Logger, pidFile string) (*grace.Watcher, error) {
 	return w, nil
 }
 
-func start(mainConf map[string]interface{}, servers map[string]grace.Server, listeners map[string]net.Listener, log *zerolog.Logger, watcher *grace.Watcher) {
+func start(mainConf map[string]interface{}, servers map[string]grace.Server, serverless *rserverless.Serverless, listeners map[string]net.Listener, log *zerolog.Logger, watcher *grace.Watcher) {
 	if isEnabledHTTP(mainConf) {
 		go func() {
 			if err := servers["http"].(*rhttp.Server).Start(listeners["http"]); err != nil {
@@ -201,6 +217,13 @@ func start(mainConf map[string]interface{}, servers map[string]grace.Server, lis
 			}
 		}()
 	}
+	if isEnabledServerless(mainConf) {
+		if err := serverless.Start(); err != nil {
+			log.Error().Err(err).Msg("error starting serverless services")
+			watcher.Exit(1)
+		}
+	}
+
 	watcher.TrapSignals()
 }
 
@@ -262,6 +285,11 @@ func getHTTPServer(conf interface{}, l *zerolog.Logger) (*rhttp.Server, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func getServerless(conf interface{}, l *zerolog.Logger) (*rserverless.Serverless, error) {
+	sub := l.With().Str("pkg", "rserverless").Logger()
+	return rserverless.New(conf, sub)
 }
 
 //	adjustCPU parses string cpu and sets GOMAXPROCS
@@ -363,6 +391,10 @@ func isEnabledHTTP(conf map[string]interface{}) bool {
 
 func isEnabledGRPC(conf map[string]interface{}) bool {
 	return isEnabled("grpc", conf)
+}
+
+func isEnabledServerless(conf map[string]interface{}) bool {
+	return isEnabled("serverless", conf)
 }
 
 func isEnabled(key string, conf map[string]interface{}) bool {

--- a/internal/serverless/services/loader/loader.go
+++ b/internal/serverless/services/loader/loader.go
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package loader
+
+// Load core serverless services.
+// Add your own service here.

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -1,0 +1,107 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package rserverless
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// Service represents a serverless service.
+type Service interface {
+	Start()
+}
+
+// Services is a map of service name and its new function.
+var Services = map[string]NewService{}
+
+// Register registers a new serverless service with name and new function.
+func Register(name string, newFunc NewService) {
+	Services[name] = newFunc
+}
+
+// NewService is the function that serverless services need to register at init time.
+type NewService func(conf map[string]interface{}, log *zerolog.Logger) (Service, error)
+
+// Serverless contains the serveless collection of services.
+type Serverless struct {
+	conf     *config
+	log      zerolog.Logger
+	services map[string]Service
+}
+
+type config struct {
+	Services map[string]map[string]interface{} `mapstructure:"services"`
+}
+
+// New returns a new serverless collection of services.
+func New(m interface{}, l zerolog.Logger) (*Serverless, error) {
+	conf := &config{}
+	if err := mapstructure.Decode(m, conf); err != nil {
+		return nil, err
+	}
+
+	n := &Serverless{
+		conf:     conf,
+		log:      l,
+		services: map[string]Service{},
+	}
+	return n, nil
+}
+
+func (s *Serverless) isServiceEnabled(svcName string) bool {
+	_, ok := Services[svcName]
+	return ok
+}
+
+// Start starts the serverless service collection.
+func (s *Serverless) Start() error {
+	if err := s.registerServices(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Serverless) registerServices() error {
+	for svcName := range s.conf.Services {
+		if s.isServiceEnabled(svcName) {
+			newFunc := Services[svcName]
+			svc, err := newFunc(s.conf.Services[svcName], &s.log)
+			if err != nil {
+				return errors.Wrapf(err, "serverless service %s could not be initialized", svcName)
+			}
+
+			go func() {
+				svc.Start()
+			}()
+			s.services[svcName] = svc
+
+			s.log.Info().Msgf("serverless service enabled: %s", svcName)
+		} else {
+			message := fmt.Sprintf("serverless service %s does not exist", svcName)
+			return errors.New(message)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds Serverless services to Reva. It is the first step before the big PR for the Notifications Service.

This adds a new type of service which doesn't have a listener (neither http or grp). As the Notifications service is communicating via NATS only with other backend services, it doesn't need to be exposed.

It could later on be used to implement other services which don't need http/grp endpoints, like metrics.