### PR TITLE
Fix path unescape in thumbnails service

### DIFF
--- a/internal/http/services/thumbnails/handler.go
+++ b/internal/http/services/thumbnails/handler.go
@@ -133,7 +133,7 @@ func (s *svc) davUserContext(next http.Handler) http.Handler {
 		ctx := r.Context()
 
 		path := r.URL.Path
-		path, _ = url.QueryUnescape(path)
+		path, _ = url.PathUnescape(path)
 
 		res, err := s.statRes(ctx, &provider.Reference{
 			Path: path,


### PR DESCRIPTION
To unescape the path the wrong method (`QueryUnescape`) was used.
This PR fixes the unescape using the correct `PathUnescape` method.